### PR TITLE
Include krb5 headers for Kerberos support

### DIFF
--- a/debian/libssl1.0.x.Dockerfile
+++ b/debian/libssl1.0.x.Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 RUN apt-get update
-RUN apt-get install -y curl wget pkg-config build-essential git zlib1g-dev
+RUN apt-get install -y curl wget pkg-config build-essential git zlib1g-dev libkrb5-dev
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/debian/libssl1.1.x.Dockerfile
+++ b/debian/libssl1.1.x.Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 RUN apt-get update
-RUN apt-get install -y curl wget pkg-config build-essential git zlib1g-dev
+RUN apt-get install -y curl wget pkg-config build-essential git zlib1g-dev libkrb5-dev
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/musl/musl.Dockerfile
+++ b/musl/musl.Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update && \
     sudo \
     xutils-dev \
     gcc-multilib-arm-linux-gnueabihf \
+    libkrb5-dev \
     && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     useradd rust --user-group --create-home --shell /bin/bash --groups sudo && \

--- a/release/release.Dockerfile
+++ b/release/release.Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye
 
 RUN apt-get update
-RUN apt-get install -y gnupg2 curl wget pkg-config build-essential git zlib1g-dev libssl-dev
+RUN apt-get install -y gnupg2 curl wget pkg-config build-essential git zlib1g-dev libssl-dev libkrb5-dev
 
 # Prisma public key. Command also sets up the folders used by GnuPG.
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 000C7F56AFE666523AC8C694D2CF263D3EA15090

--- a/rhel/libssl1.0.x.Dockerfile
+++ b/rhel/libssl1.0.x.Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:6
 
 RUN yum groupinstall 'Development Tools' -y
-RUN yum install git curl pkg-config openssl-devel -y
+RUN yum install git curl pkg-config openssl-devel krb5-devel -y
 
 # Install Rust
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y

--- a/rhel/libssl1.1.x.Dockerfile
+++ b/rhel/libssl1.1.x.Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:6
 
 RUN yum groupinstall 'Development Tools' -y
-RUN yum install git curl pkg-config perl-core zlib-devel wget -y
+RUN yum install git curl pkg-config perl-core zlib-devel wget krb5-devel -y
 
 # Install Rust
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH ${SCALA_HOME}/bin:${SBT_HOME}/bin:/root/.cargo/bin:$PATH
 ENV LD_LIBRARY_PATH=/lib:/usr/lib:/usr/include/linux:/lib/x86_64-linux-gnu
 
 # Dependencies
-RUN apt-get update && apt-get -y install wget curl git make build-essential libz-dev libsqlite3-dev openssl libssl-dev pkg-config gzip mingw-w64 openjdk-8-jdk
+RUN apt-get update && apt-get -y install wget curl git make build-essential libz-dev libsqlite3-dev openssl libssl-dev pkg-config gzip mingw-w64 openjdk-8-jdk libkrb5-dev
 RUN mkdir -p $SCALA_HOME
 RUN mkdir -p $SBT_HOME
 


### PR DESCRIPTION
This allows the Tiberius builds to pass when including the `gssapi` support, requiring the libkrb5 headers. And in the future, if we plan to enable Kerberos authentication on Prisma/MSSQL on Linux platforms.

It is possible to install krb5 for OSX and FreeBSD, but I'll leave them to be until we actually want to enable this feature in Prisma.