### PR TITLE
Upgrade base image of RHEL dockerfiles

### DIFF
--- a/rhel/libssl1.0.x.Dockerfile
+++ b/rhel/libssl1.0.x.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6
+FROM centos:7
 
 RUN yum groupinstall 'Development Tools' -y
 RUN yum install git curl pkg-config openssl-devel krb5-devel gss-devel clang-devel -y

--- a/rhel/libssl1.1.x.Dockerfile
+++ b/rhel/libssl1.1.x.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6
+FROM centos:7
 
 RUN yum groupinstall 'Development Tools' -y
 RUN yum install git curl pkg-config perl-core zlib-devel wget krb5-devel gss-devel clang-devel -y


### PR DESCRIPTION
It looks like we're using a base image with a really old centos version
and the SSL certificates for the package repos don't match anymore.
Trying an upgrade to a more recent centos version.