### PR TITLE
Add dynamic lookup for macOS napi builds

### DIFF
--- a/cross/darwin.Dockerfile
+++ b/cross/darwin.Dockerfile
@@ -22,3 +22,4 @@ ENV CXX=o64-clang++
 RUN echo "[target.x86_64-apple-darwin]" >> ~/.cargo/config
 RUN echo "linker = \"x86_64-apple-darwin14-clang\"" >> ~/.cargo/config
 RUN echo "ar = \"x86_64-apple-darwin14-ar\"" >> ~/.cargo/config
+RUN echo "rustflags = [\"-C\", \"link-args=-undefined dynamic_lookup\"]" >> ~/.cargo/config


### PR DESCRIPTION
This allows linking on macOS cross-compilation with no proper N-API headers (will be checked on runtime).