### PR TITLE
Add proper Alpine Linux build image

### DIFF
--- a/musl/Makefile
+++ b/musl/Makefile
@@ -1,7 +1,11 @@
-build: build-musl
+build: build-musl build-alpine
 
 build-musl:
 	docker build -f musl.Dockerfile -t prismagraphql/build:musl .
 
+build-alpine:
+	docker build -f alpine.Dockerfile -t prismagraphql/build:alpine .
+
 push:
 	docker push prismagraphql/build:musl
+	docker push prismagraphql/build:alpine

--- a/musl/alpine.Dockerfile
+++ b/musl/alpine.Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10-alpine
+
+ENV RUSTFLAGS="-C target-feature=-crt-static" \
+  PATH="/usr/local/cargo/bin/rustup:/root/.cargo/bin:$PATH" \
+  CC="clang" \
+  CXX="clang++"
+
+RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories && \
+  apk update && \
+  apk add rustup musl-dev build-base bash clang openssl-dev git && \
+  rustup-init -y


### PR DESCRIPTION
This will make napi builds simpler, and the dockerfiles simpler too. The normal builds will continue to use the old image still, but this adds me a new alpine build image for further tests.