### PR TITLE
Add Clippy to images

### DIFF
--- a/cross/darwin.Dockerfile
+++ b/cross/darwin.Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get -y install wget curl git make build-essential clan
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN rustup target add x86_64-apple-darwin
+RUN rustup component add clippy
 
 # Install OSX cross toolchain
 RUN apt-get install -y cmake libxml2-dev

--- a/cross/linux-arm-ssl-1.0.x.Dockerfile
+++ b/cross/linux-arm-ssl-1.0.x.Dockerfile
@@ -17,6 +17,7 @@ ENV OPENSSL_DIR=/opt/openssl-arm
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup component add clippy
 
 # from rust cross - https://github.com/rust-embedded/cross/blob/master/docker/Dockerfile.aarch64-unknown-linux-gnu#L27
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/cross/linux-arm-ssl-1.1.x.Dockerfile
+++ b/cross/linux-arm-ssl-1.1.x.Dockerfile
@@ -17,6 +17,7 @@ ENV OPENSSL_DIR=/opt/openssl-arm
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup component add clippy
 
 # from rust cross - https://github.com/rust-embedded/cross/blob/master/docker/Dockerfile.aarch64-unknown-linux-gnu#L27
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/cross/windows.Dockerfile
+++ b/cross/windows.Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get -y install wget curl git make build-essential libz
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN rustup target add x86_64-pc-windows-gnu
+RUN rustup component add clippy
 
 RUN echo "[target.x86_64-pc-windows-gnu]" >> ~/.cargo/config
 RUN echo "linker = \"/usr/bin/x86_64-w64-mingw32-gcc\"" >> ~/.cargo/config

--- a/musl/alpine.Dockerfile
+++ b/musl/alpine.Dockerfile
@@ -9,3 +9,4 @@ RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories && \
   apk update && \
   apk add rustup musl-dev build-base bash clang openssl-dev git && \
   rustup-init -y
+RUN rustup component add clippy

--- a/musl/musl.Dockerfile
+++ b/musl/musl.Dockerfile
@@ -82,6 +82,7 @@ RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- -y --default-toolchain $TOOLCHAIN && \
     rustup target add x86_64-unknown-linux-musl && \
     rustup target add armv7-unknown-linux-musleabihf
+RUN rustup component add clippy
 
 
 ADD cargo-config.toml /root/.cargo/config

--- a/rhel/libssl1.0.x.Dockerfile
+++ b/rhel/libssl1.0.x.Dockerfile
@@ -7,3 +7,4 @@ RUN yum install wget git curl perl-core zlib-devel openssl openssl-devel -y
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
 RUN rustup default stable
+RUN rustup component add clippy

--- a/rhel/libssl1.1.x.Dockerfile
+++ b/rhel/libssl1.1.x.Dockerfile
@@ -23,3 +23,4 @@ ENV OPENSSL_LIB_DIR /usr/local/ssl/lib
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
 RUN rustup default stable
+RUN rustup component add clippy

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -26,6 +26,7 @@ RUN curl -fsL https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-$
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN rustup install nightly
 RUN rustup default stable
+RUN rustup component add clippy
 
 # Initialize SBT
 RUN sbt exit


### PR DESCRIPTION
Adds clippy to the docker images. This is to make progress towards https://github.com/prisma/prisma-engines/issues/1453. Thanks!