### PR TITLE
cockroach: remove null_ordered_last

### DIFF
--- a/cockroach/prisma_init.sql
+++ b/cockroach/prisma_init.sql
@@ -1,8 +1,6 @@
 CREATE USER prisma;
 GRANT admin TO prisma;
 
-ALTER USER prisma SET null_ordered_last = true;
-
 SET CLUSTER SETTING sql.defaults.default_int_size = 4;
 SET CLUSTER SETTING sql.defaults.serial_normalization = 'sql_sequence';
 SET CLUSTER SETTING schemachanger.backfiller.buffer_increment = '128 KiB';


### PR DESCRIPTION
This is inefficient, and the tests that rely on this behaviour have been
changed to NULLS FIRST in [prisma-engines#2500.](https://github.com/prisma/prisma-engines/pull/2500)