### PR TITLE
Cockroach: Change image to 21.2 with backported changes

### DIFF
--- a/cockroach/cockroach.Dockerfile
+++ b/cockroach/cockroach.Dockerfile
@@ -1,2 +1,2 @@
-FROM otanatcockroach/cockroachdb-custom:v2.1.1
+FROM otanatcockroach/cockroachdb-custom:v21.2-patched
 COPY prisma_init.sql /docker-entrypoint-initdb.d/prisma_init.sql


### PR DESCRIPTION
This image is the official 21.2 with these additional backported changes: https://github.com/cockroachdb/cockroach/pull/73666/commits