### PR TITLE
Remove `mdbook-graphviz` from musl image (it's broken)

### DIFF
--- a/musl/musl.Dockerfile
+++ b/musl/musl.Dockerfile
@@ -152,7 +152,6 @@ ENV OPENSSL_DIR=/usr/local/musl/ \
 # We include cargo-audit for compatibility with earlier versions of this image,
 # but cargo-deny provides a super-set of cargo-audit's features.
 RUN cargo install -f cargo-audit && \
-    cargo install -f mdbook-graphviz && \
     rm -rf /root/.cargo/registry/
 
 WORKDIR /root/build


### PR DESCRIPTION
Even broken if you try to install from your own terminal. Removed it, tested the build and saw it working on my machine.