### PR TITLE
Remove workaround cluster settings on crdb image

### DIFF
--- a/cockroach/prisma_init.sql
+++ b/cockroach/prisma_init.sql
@@ -1,8 +1,6 @@
 CREATE USER prisma;
 GRANT admin TO prisma;
 
-SET CLUSTER SETTING sql.defaults.default_int_size = 4;
-SET CLUSTER SETTING sql.defaults.serial_normalization = 'sql_sequence';
 SET CLUSTER SETTING schemachanger.backfiller.buffer_increment = '128 KiB';
 SET CLUSTER SETTING sql.catalog.unsafe_skip_system_config_trigger.enabled = true;
 SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms';


### PR DESCRIPTION
This is so we can test closer to defaults.