### PR TITLE
Try cockroachdb 22.1 alpha 2

### DIFF
--- a/cockroach/cockroach.Dockerfile
+++ b/cockroach/cockroach.Dockerfile
@@ -1,2 +1,2 @@
-FROM cockroachdb/cockroach-unstable:v22.1.0-beta.1
+FROM cockroachdb/cockroach-unstable:v22.1.0-alpha.2
 COPY prisma_init.sql /docker-entrypoint-initdb.d/prisma_init.sql


### PR DESCRIPTION
beta.1 is slow in QE tests, alpha 1 is fast. Let's see with which
release things started getting slow.