### PR TITLE
Delete obsolete line in cockroachdb init

### DIFF
--- a/cockroach/22.1.0/prisma_init.sql
+++ b/cockroach/22.1.0/prisma_init.sql
@@ -3,9 +3,6 @@ GRANT admin TO prisma;
 
 -- Testing only configuration for CockroachDB
 
--- During table backfills, we fill up buffers which have a large default. A lower setting reduces memory usage.
-SET CLUSTER SETTING schemachanger.backfiller.buffer_increment = '128 KiB';
-
 -- Frequent table create/drop creates extra ranges, which we want to merge quickly. In real usage, range merges are rate limited because they require rebalancing
 SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms';
 


### PR DESCRIPTION
The option does not exist anymore in 22.1

![2022-06-24_13-06-36](https://user-images.githubusercontent.com/13155277/175529047-954bf0cb-99cf-4bc0-b427-7f689504e22f.png)
