### PR TITLE
fix(test): add rustup bin path to $PATH

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -12,3 +12,4 @@ RUN curl -sSL https://get.docker.com/ | sh
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
That broke with https://github.com/prisma/engine-images/pull/56

I confirmed manually locally that `cargo` reachable from `PATH` after this change.