### PR TITLE
Use Debian Stretch to build where we can

### DIFF
--- a/debian/libssl1.0.x.Dockerfile
+++ b/debian/libssl1.0.x.Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:bullseye
+FROM debian:jessie
 
 RUN apt-get update
-RUN apt-get install -y curl wget pkg-config build-essential git zlib1g-dev libkrb5-dev libgss-dev libclang-dev ca-certificates
+RUN apt-get install -y --force-yes curl wget pkg-config build-essential git zlib1g-dev libkrb5-dev libgss-dev libclang-dev ca-certificates
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -11,12 +11,12 @@ ENV PATH=/root/.cargo/bin:$PATH
 RUN sed '/DST_Root_CA_X3.crt/d' /etc/ca-certificates.conf > /tmp/cacerts.conf && mv /tmp/cacerts.conf /etc/ca-certificates.conf
 RUN update-ca-certificates
 
-RUN wget https://www.openssl.org/source/openssl-1.0.1u.tar.gz
-RUN tar -xf openssl-1.0.1u.tar.gz
-RUN cd openssl-1.0.1u && ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && make
-RUN cd openssl-1.0.1u && make test
-RUN cd openssl-1.0.1u && make install
-RUN cd /etc/ld.so.conf.d/ && echo "/usr/local/ssl/lib" > openssl-1.0.1u.conf
+RUN wget https://www.openssl.org/source/openssl-1.0.2u.tar.gz
+RUN tar -xf openssl-1.0.2u.tar.gz
+RUN cd openssl-1.0.2u && ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && make
+RUN cd openssl-1.0.2u && make test
+RUN cd openssl-1.0.2u && make install
+RUN cd /etc/ld.so.conf.d/ && echo "/usr/local/ssl/lib" > openssl-1.0.2u.conf
 RUN ldconfig -v
 
 ENV PATH=/usr/local/ssl/bin:$PATH

--- a/debian/libssl1.1.x.Dockerfile
+++ b/debian/libssl1.1.x.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:stretch
 
 RUN apt-get update
 RUN apt-get install -y curl wget pkg-config build-essential git zlib1g-dev libkrb5-dev libgss-dev libclang-dev  ca-certificates
@@ -11,12 +11,12 @@ ENV PATH=/root/.cargo/bin:$PATH
 RUN sed '/DST_Root_CA_X3.crt/d' /etc/ca-certificates.conf > /tmp/cacerts.conf && mv /tmp/cacerts.conf /etc/ca-certificates.conf
 RUN update-ca-certificates
 
-RUN wget https://www.openssl.org/source/openssl-1.1.0l.tar.gz
-RUN tar -xf openssl-1.1.0l.tar.gz
-RUN cd openssl-1.1.0l && ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && make
-# RUN cd openssl-1.1.0l && make test
-RUN cd openssl-1.1.0l && make install
-RUN cd /etc/ld.so.conf.d/ && echo "/usr/local/ssl/lib" > openssl-1.1.0l.conf
+RUN wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz
+RUN tar -xf openssl-1.1.1s.tar.gz
+RUN cd openssl-1.1.1s && ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && make
+# RUN cd openssl-1.1.1s && make test
+RUN cd openssl-1.1.1s && make install
+RUN cd /etc/ld.so.conf.d/ && echo "/usr/local/ssl/lib" > openssl-1.1.1s.conf
 RUN ldconfig -v
 
 ENV PATH=/usr/local/ssl/bin:$PATH

--- a/debian/libssl3.0.x.Dockerfile
+++ b/debian/libssl3.0.x.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:stretch
 
 RUN apt-get update
 RUN apt-get install -y curl wget pkg-config build-essential git zlib1g-dev libkrb5-dev libgss-dev libclang-dev ca-certificates
@@ -11,12 +11,12 @@ ENV PATH=/root/.cargo/bin:$PATH
 RUN sed '/DST_Root_CA_X3.crt/d' /etc/ca-certificates.conf > /tmp/cacerts.conf && mv /tmp/cacerts.conf /etc/ca-certificates.conf
 RUN update-ca-certificates
 
-RUN wget https://www.openssl.org/source/openssl-3.0.2.tar.gz
-RUN tar -xf openssl-3.0.2.tar.gz
-RUN cd openssl-3.0.2 && ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && make
-# RUN cd openssl-3.0.2 && make test
-RUN cd openssl-3.0.2 && make install
-RUN cd /etc/ld.so.conf.d/ && echo "/usr/local/ssl/lib64" > openssl-3.0.2.conf
+RUN wget https://www.openssl.org/source/openssl-3.0.7.tar.gz
+RUN tar -xf openssl-3.0.7.tar.gz
+RUN cd openssl-3.0.7 && ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && make
+# RUN cd openssl-3.0.7 && make test
+RUN cd openssl-3.0.7 && make install
+RUN cd /etc/ld.so.conf.d/ && echo "/usr/local/ssl/lib64" > openssl-3.0.7.conf
 RUN ldconfig -v
 
 ENV PATH=/usr/local/ssl/bin:$PATH


### PR DESCRIPTION
- Jessie is only used with OpenSSL 1.0.x build
- All others use Stretch

Also updates OpenSSL to the latest minor versions