### PR TITLE
crdb: add 22.2

### DIFF
--- a/cockroach/22.2/Dockerfile
+++ b/cockroach/22.2/Dockerfile
@@ -1,0 +1,2 @@
+FROM cockroachdb/cockroach:latest-v22.2
+COPY prisma_init.sql /docker-entrypoint-initdb.d/prisma_init.sql

--- a/cockroach/22.2/prisma_init.sql
+++ b/cockroach/22.2/prisma_init.sql
@@ -1,0 +1,31 @@
+CREATE USER prisma;
+GRANT admin TO prisma;
+
+-- Testing only configuration for CockroachDB
+
+-- Frequent table create/drop creates extra ranges, which we want to merge quickly. In real usage, range merges are rate limited because they require rebalancing
+SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms';
+
+-- Setting improves performance by not syncing data to disk. Data is lost if a node crashes. This matches another recommendation to use cockroach start-single-node --store-type=mem.
+SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = true;
+
+-- More schema changes create more jobs, which affects job queries performance. We don’t need to retain jobs during testing so can set a more aggressive delete policy.
+SET CLUSTER SETTING jobs.retention_time = '15s';
+
+-- This is one example of an internal task that queries the jobs table. For testing, the default is too fast.
+SET CLUSTER SETTING jobs.registry.interval.cancel = '180s';
+
+-- CockroachDB executes queries that scan the jobs table. More schema changes creates more jobs, which we can delete faster to make job queries faster.
+SET CLUSTER SETTING jobs.registry.interval.gc = '30s';
+
+-- Automatics statistics contribute to table contention alongside schema changes. A schema change triggers an asynchronous auto stats job.
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+
+-- tl;dr we want to quickly discard ranges on DROP DATABASE.
+-- longer version: By default we prevent ranges being merged within 5mins as there is usually thrashing if we merge ranges sooner. However, if we want ranges to be disposed quickly (e.g. in CI), we want this much lower so that we can discard dropped database objects quicker.
+SET CLUSTER SETTING kv.range_split.by_load_merge_delay = '5s';
+
+-- Faster descriptor cleanup.
+ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = '5';
+-- Faster jobs table cleanup.
+ALTER DATABASE system CONFIGURE ZONE USING gc.ttlseconds = '5';

--- a/cockroach/Makefile
+++ b/cockroach/Makefile
@@ -1,4 +1,4 @@
-build: build-21.2.0-patched build-22.1.0-alpha.1 build-22.1.0-beta.2 build-22.1.0-beta.5 build-22.1.0
+build: build-21.2.0-patched build-22.1.0-alpha.1 build-22.1.0-beta.2 build-22.1.0-beta.5 build-22.1.0 build-22.2
 
 build-21.2.0-patched:
 	docker build -t prismagraphql/cockroachdb-custom:21.2.0-patched ./21.2.0-patched
@@ -15,9 +15,13 @@ build-22.1.0-beta.5:
 build-22.1.0:
 	docker build -t prismagraphql/cockroachdb-custom:22.1.0 ./22.1.0
 
+build-22.2:
+	docker build -t prismagraphql/cockroachdb-custom:22.2 ./22.2
+
 push:
 	docker push prismagraphql/cockroachdb-custom:21.2.0-patched
 	docker push prismagraphql/cockroachdb-custom:22.1.0-alpha.1
 	docker push prismagraphql/cockroachdb-custom:22.1.0-beta.2
 	docker push prismagraphql/cockroachdb-custom:22.1.0-beta.5
 	docker push prismagraphql/cockroachdb-custom:22.1.0
+	docker push prismagraphql/cockroachdb-custom:22.2


### PR DESCRIPTION
No minor version number because we test major versions, not minors. We should rename 22.1.0 but let's not do it to avoid breakage.