### PR TITLE
Make ARM cross-compilation images build successfully

### DIFF
--- a/cross/darwin.Dockerfile
+++ b/cross/darwin.Dockerfile
@@ -4,6 +4,9 @@ FROM debian:stretch
 ENV PATH=/root/.cargo/bin:$PATH
 ENV LD_LIBRARY_PATH=/lib:/usr/lib:/usr/include/linux:/lib/x86_64-linux-gnu
 
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get -y install wget curl git make build-essential clang libz-dev libsqlite3-dev openssl libssl-dev pkg-config gzip mingw-w64 g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/cross/linux-arm-ssl-1.0.x.Dockerfile
+++ b/cross/linux-arm-ssl-1.0.x.Dockerfile
@@ -3,6 +3,9 @@ FROM debian:stretch
 
 ENV PATH=/root/.cargo/bin:$PATH
 
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get -y install wget curl git make build-essential clang libz-dev libsqlite3-dev openssl libssl-dev pkg-config gzip mingw-w64 g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev gcc-aarch64-linux-gnu
 
 # cross compile OpenSSL

--- a/cross/linux-arm-ssl-1.1.x.Dockerfile
+++ b/cross/linux-arm-ssl-1.1.x.Dockerfile
@@ -3,6 +3,9 @@ FROM debian:stretch
 
 ENV PATH=/root/.cargo/bin:$PATH
 
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get -y install wget curl git make build-essential clang libz-dev libsqlite3-dev openssl libssl-dev pkg-config gzip mingw-w64 g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev gcc-aarch64-linux-gnu
 
 # cross compile OpenSSL

--- a/cross/linux-arm-ssl-3.0.x.Dockerfile
+++ b/cross/linux-arm-ssl-3.0.x.Dockerfile
@@ -3,6 +3,9 @@ FROM debian:stretch
 
 ENV PATH=/root/.cargo/bin:$PATH
 
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get -y install wget curl git make build-essential clang libz-dev libsqlite3-dev openssl libssl-dev pkg-config gzip mingw-w64 g++ zlib1g-dev libmpc-dev libmpfr-dev libgmp-dev gcc-aarch64-linux-gnu
 
 # cross compile OpenSSL

--- a/cross/windows.Dockerfile
+++ b/cross/windows.Dockerfile
@@ -3,6 +3,9 @@ FROM debian:stretch
 ENV PATH=/root/.cargo/bin:$PATH
 ENV LD_LIBRARY_PATH=/lib:/usr/lib:/usr/include/linux:/lib/x86_64-linux-gnu
 
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get -y install wget curl git make build-essential libz-dev libsqlite3-dev openssl libssl-dev pkg-config gzip mingw-w64
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y


### PR DESCRIPTION
Hotfix ARM cross-compilation images to build successfully by updating
their apt sources to point to archive.debian.org. This is necessary to
unblock all other work happening in the engine-images repo, and to make
it possible to update these images.

The issue for a proper long-term fix is https://github.com/prisma/team-orm/issues/175.
