### PR TITLE
Use custom image for linux-static-arm64

### DIFF
--- a/linux-static/aarch64-musl-config.mak
+++ b/linux-static/aarch64-musl-config.mak
@@ -1,0 +1,18 @@
+OUTPUT = /opt/cross
+
+GCC_VER = 11.2.0
+
+# This should match the musl version that the Rust compiler uses.
+# It isn't updated often (last time it was updated to 1.2.3 in Rust 1.71,
+# before that it was 1.1.24 since Rust 1.46).
+MUSL_VER = 1.2.3
+
+DL_CMD = curl -C - -L -o
+
+COMMON_CONFIG += CFLAGS="-g0 -Os -w" CXXFLAGS="-g0 -Os -w" LDFLAGS="-s"
+COMMON_CONFIG += --disable-nls
+COMMON_CONFIG += --with-debug-prefix-map=$(CURDIR)=
+
+GCC_CONFIG += --enable-languages=c,c++
+GCC_CONFIG += --disable-libquadmath --disable-decimal-float
+GCC_CONFIG += --disable-multilib

--- a/linux-static/linux-static-arm64.Dockerfile
+++ b/linux-static/linux-static-arm64.Dockerfile
@@ -1,3 +1,29 @@
-# Using https://github.com/rust-cross/rust-musl-cross
+FROM debian:bookworm
 
-FROM messense/rust-musl-cross:aarch64-musl
+ENV PATH=/root/.cargo/bin:/opt/cross/bin:$PATH
+
+RUN apt-get update && \
+    apt-get install -y build-essential curl file git bison flex
+
+COPY ./aarch64-musl-config.mak /tmp/config.mak
+
+# Build cross-compiling toolchain using https://github.com/richfelker/musl-cross-make,
+# https://github.com/rust-cross/rust-musl-cross.
+# See also `../cross/linux-musl-arm.Dockerfile`.
+RUN cd /tmp && \
+    git clone --depth 1 https://github.com/richfelker/musl-cross-make.git && \
+    cp /tmp/config.mak /tmp/musl-cross-make/config.mak && \
+    cd /tmp/musl-cross-make && \
+    export CFLAGS="-fPIC -g1" && \
+    export TARGET=aarch64-unknown-linux-musl && \
+    make -j$(nproc) && make install && \
+    cd /tmp && rm -rf /tmp/musl-cross-make
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN rustup target add aarch64-unknown-linux-musl
+
+RUN echo '[target.aarch64-unknown-linux-musl]' > /root/.cargo/config && \
+    echo 'linker = "aarch64-unknown-linux-musl-gcc"' >> /root/.cargo/config
+
+ENV CC_aarch64_unknown_linux_musl=aarch64-unknown-linux-musl-gcc
+ENV CXX_aarch64_unknown_linux_musl=aarch64-unknown-linux-musl-g++


### PR DESCRIPTION
Use custom image for static arm64 builds, which is now essentially a copy of our Dockerfile for dynamically linked arm64 musl builds but with irrelevant parts removed.

See https://github.com/prisma/team-orm/issues/608 for rationale and detailed description.

This Dockerfile was tested locally with commands identical to those `engineer` runs:

- `docker run -it --rm -v $(pwd):/work -w /work -e SQLITE_MAX_VARIABLE_NUMBER=250000 -e SQLITE_MAX_EXPR_DEPTH=10000 -e LIBZ_SYS_STATIC=1 docker.io/prismagraphql/build:linux-static-arm64 bash` to run the image
- `cargo build --release -p query-engine --target aarch64-unknown-linux-musl --features vendored-openssl` etc to build a specific package

(the only difference is that technically engineer runs it as a single command without a shell in between and builds each binary in a separate container but it doesn't matter)

Closes: https://github.com/prisma/team-orm/issues/608
