### PR TITLE
fix: use Amazon Linux base image for glibc builds

### DIFF
--- a/rhel/libssl1.0.x.Dockerfile
+++ b/rhel/libssl1.0.x.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM amazonlinux:1
 
 RUN yum groupinstall 'Development Tools' -y
 RUN yum install wget git curl perl-core zlib-devel openssl openssl-devel -y

--- a/rhel/libssl1.1.x.Dockerfile
+++ b/rhel/libssl1.1.x.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM amazonlinux:1
 
 RUN yum groupinstall 'Development Tools' -y
 RUN yum install wget git curl perl-core zlib-devel ca-certificates -y

--- a/rhel/libssl3.0.x.Dockerfile
+++ b/rhel/libssl3.0.x.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM amazonlinux:1
 
 RUN yum groupinstall 'Development Tools' -y
 RUN yum install wget git curl perl-core zlib-devel ca-certificates -y


### PR DESCRIPTION
CentOS 7 is EOL so the glibc builds are now failed. We can consider
raising the minimum supported glibc version from 2.17 to something more
modern in Prisma 6 but for now we need to maintain compatibility with
the same range of platforms.

This PR changes the base image to Amazon Linux 1, which is the only RHEL
7 derivative which is still maintained.
